### PR TITLE
Removed two *.ahbl.org blacklists that are closing down so to not return back false Listed results.

### DIFF
--- a/rblwatch.py
+++ b/rblwatch.py
@@ -76,7 +76,6 @@ RBLS = [
     'spamlist.or.kr',
     'spamrbl.imp.ch',
     't3direct.dnsbl.net.au',
-    'tor.ahbl.org',
     'tor.dnsbl.sectoor.de',
     'torserver.tor.dnsbl.sectoor.de',
     'ubl.lashback.com',

--- a/rblwatch.py
+++ b/rblwatch.py
@@ -25,7 +25,6 @@ RBLS = [
     'dnsbl-1.uceprotect.net',
     'dnsbl-2.uceprotect.net',
     'dnsbl-3.uceprotect.net',
-    'dnsbl.ahbl.org',
     'dnsbl.cyberlogic.net',
     'dnsbl.dronebl.org',
     'dnsbl.inps.de',


### PR DESCRIPTION
See http://www.ahbl.org/content/changes-ahbl for their announcement of closing the service, and also verify on www.mxutils.com.