### PR TITLE
TypeError: sequence item 0: expected str instance, bytes found

### DIFF
--- a/rblwatch/rblwatch.py
+++ b/rblwatch/rblwatch.py
@@ -105,7 +105,7 @@ class Lookup(Thread):
                 self.listed[self.dnslist]['HOST'] = host_record[0].address
                 text_record = self.resolver.query(self.host, "TXT")
                 if len(text_record) > 0:
-                    self.listed[self.dnslist]['TEXT'] = "\n".join(text_record[0].strings)
+                    self.listed[self.dnslist]['TEXT'] = text_record[0].to_text()
             self.listed[self.dnslist]['ERROR'] = False
         except NXDOMAIN:
             self.listed[self.dnslist]['ERROR'] = True
@@ -166,7 +166,7 @@ class RBLSearch(object):
                     print("  + Host information: %s" % \
                           (listed[key]['HOST']))
                 if 'TEXT' in listed[key].keys():
-                    print("    + Additional information: %s" % \
+                    print("    + Additional information:\n      %s" % \
                           (listed[key]['TEXT']))
             else:
                 #print "*** Error contacting %s ***" % key


### PR DESCRIPTION
Hey thanks for a great tool, I however ran into a problem when running the code is below, Its from your example and the IP is currently blacklisted. The TEXT record was throwing an error, I managed to "fix" it with this pull request.

```
from rblwatch import RBLSearch

# Do the lookup (for smtp.gmail.com)
searcher = RBLSearch('85.115.52.190')

# Display a simply formatted report of the results
searcher.print_results()

# Use the result data for something else
result_data = searcher.listed
```
